### PR TITLE
refactor: remove global eslint disables and add types

### DIFF
--- a/src/components/builder/LeftDock.tsx
+++ b/src/components/builder/LeftDock.tsx
@@ -1,13 +1,12 @@
 'use client'
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-import { useState, useEffect } from 'react'
+import { useState, useEffect, type ReactNode } from 'react'
+import type { Editor } from 'grapesjs'
 import GlobalStylesPanel from './GlobalStylesPanel'
 
 export default function LeftDock() {
   const [activePanel, setActivePanel] = useState<string>('pages-layers')
-  const [editor, setEditor] = useState<any>(null)
+  const [editor, setEditor] = useState<Editor | null>(null)
   const [showDrawer, setShowDrawer] = useState<boolean>(false)
   const [showGlobalStyles, setShowGlobalStyles] = useState<boolean>(false)
   const [drawerContent, setDrawerContent] = useState<{
@@ -17,7 +16,15 @@ export default function LeftDock() {
     panelElement?: HTMLElement
   } | null>(null)
 
-  const dockItems = [
+  interface DockItem {
+    id: string
+    command?: string
+    icon: ReactNode
+    label: string
+    active: boolean
+  }
+
+  const dockItems: DockItem[] = [
     {
       id: 'pages-layers',
       command: 'open-pages-layers',
@@ -66,20 +73,26 @@ export default function LeftDock() {
 
   useEffect(() => {
     // Listen for GrapesJS ready event
-    const handleGjsReady = (event: CustomEvent) => {
-      const editorInstance = event.detail
-      setEditor(editorInstance)
+    const handleGjsReady = (event: CustomEvent<Editor>) => {
+      setEditor(event.detail)
     }
 
     // Listen for panel change events from GrapesJS
-    const handlePanelChange = (event: CustomEvent) => {
+    const handlePanelChange = (event: CustomEvent<{ panelId: string }>) => {
       if (event.detail.panelId) {
         setActivePanel(event.detail.panelId)
       }
     }
 
     // Listen for drawer show events
-    const handleShowDrawer = (event: CustomEvent) => {
+    const handleShowDrawer = (
+      event: CustomEvent<{
+        panelType: string
+        pagesElement?: HTMLElement
+        layersElement?: HTMLElement
+        panelElement?: HTMLElement
+      }>
+    ) => {
       const { panelType, pagesElement, layersElement, panelElement } = event.detail
       setDrawerContent({
         type: panelType,
@@ -101,7 +114,7 @@ export default function LeftDock() {
     }
   }, [])
 
-  const handleItemClick = (item: any) => {
+  const handleItemClick = (item: DockItem) => {
     if (editor && item.command) {
       // Set active panel
       setActivePanel(item.id)

--- a/src/lib/gjs/blocks.ts
+++ b/src/lib/gjs/blocks.ts
@@ -3,6 +3,8 @@
  * Registers custom block categories and components for the visual editor
  */
 
+import type { Editor, BlockProperties } from 'grapesjs'
+
 /**
  * Block categories configuration
  */
@@ -24,7 +26,7 @@ export const blockCategories = [
 /**
  * Custom blocks configuration
  */
-export const customBlocks = [
+export const customBlocks: CustomBlock[] = [
   // Basic Category
   {
     id: 'heading-custom',
@@ -345,7 +347,11 @@ export const blocksToRemove = [
  * Register custom blocks and configure the Block Manager
  * @param editor - The GrapesJS editor instance
  */
-export function registerBlocks(editor: any): void {
+interface CustomBlock extends BlockProperties {
+  id: string
+}
+
+export function registerBlocks(editor: Editor): void {
   if (!editor) {
     console.warn('Editor instance not provided to registerBlocks')
     return
@@ -363,7 +369,7 @@ export function registerBlocks(editor: any): void {
     blocksToRemove.forEach((blockId: string) => {
       try {
         blockManager.remove?.(blockId)
-      } catch (e) {
+      } catch {
         // Ignore errors when removing non-existent blocks
       }
     })
@@ -372,7 +378,7 @@ export function registerBlocks(editor: any): void {
     // Categories will be created automatically when blocks are added with category property
 
     // Add custom blocks - categories will be created automatically
-    customBlocks.forEach((block: any) => {
+    customBlocks.forEach((block) => {
       try {
         blockManager.add(block.id, {
           label: block.label,
@@ -391,13 +397,12 @@ export function registerBlocks(editor: any): void {
   }
 }
 
-import type { Editor } from 'grapesjs'
-
 export function registerBasicBlocks(editor: Editor) {
-  const bm = editor.BlockManager
+  const bm = editor.BlockManager as unknown as {
+    addCategory?: (id: string, opts: { label: string; open: boolean }) => void
+  }
   // Attempt to create/open the 'basic' category when supported (GrapesJS >= 0.21)
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  ;(bm as any).addCategory?.('basic', { label: 'Basic', open: true })
+  bm.addCategory?.('basic', { label: 'Basic', open: true })
 
   bm.add('section', {
     label: 'Section',


### PR DESCRIPTION
## Summary
- remove file-level ESLint disables
- add explicit types for editor callbacks and panel attributes
- adjust blocks typing and cleanup unused error variable

## Testing
- `npx eslint src/lib/gjs/panels.ts src/components/builder/LeftDock.tsx src/lib/gjs/blocks.ts`
- `npm run lint` *(fails: Unexpected any in unrelated files)*


------
https://chatgpt.com/codex/tasks/task_e_68add679b2a0832389048c9679f380d6