### PR TITLE
feat: add workspace type

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { listWorkspaces, getWorkspace } from '../lib/store'
+import type { Workspace } from '../lib/types'
 import Button from './ui/Button'
 import Dropdown from './ui/Dropdown'
 
@@ -16,7 +17,8 @@ const CURRENT_WORKSPACE_KEY = 'currentWS'
 const AppShell = ({ children }: AppShellProps) => {
   const router = useRouter()
   const workspaces = listWorkspaces()
-  const [currentWorkspace, setCurrentWorkspace] = useState<any>(null) // Initialize as null to prevent hydration mismatch
+  // Initialize as null to prevent hydration mismatch
+  const [currentWorkspace, setCurrentWorkspace] = useState<Workspace | null>(null)
   const [isClient, setIsClient] = useState(false)
 
   // Load current workspace from localStorage on mount
@@ -44,7 +46,7 @@ const AppShell = ({ children }: AppShellProps) => {
   }, [workspaces])
 
   // Handle workspace selection
-  const handleWorkspaceSelect = (workspace: any) => {
+  const handleWorkspaceSelect = (workspace: Workspace) => {
     setCurrentWorkspace(workspace)
     localStorage.setItem(CURRENT_WORKSPACE_KEY, workspace.id)
     router.push('/projects') // Navigate to projects page to show updated workspace content

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,9 @@
-export type Workspace = {
+export interface Workspace {
   id: string;
   name: string;
   role?: 'owner' | 'admin' | 'member';
   createdAt: number;
-};
+}
 
 export type ProjectStatus = 'draft' | 'published';
 


### PR DESCRIPTION
## Summary
- define `Workspace` interface for workspace data
- type workspace state and handler in `AppShell`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 48 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68add6798d188323af0ccfb0f1db02a4