### PR TITLE
Validate domain requests before database access

### DIFF
--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { query } from '@/lib/db'
+import { z } from 'next/dist/compiled/zod'
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url)
@@ -17,17 +18,34 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const url = new URL(req.url)
   const legacyProjectSlug = url.searchParams.get('project') || ''
-  const body = await req.json().catch(() => ({} as any))
-  const projectId: string | undefined = body.projectId
-  const hostname: string | undefined = body.hostname || body.domain
+  const rawBody: unknown = await req.json().catch(() => ({}))
+  const body = rawBody as Record<string, unknown>
+
+  const BodySchema = z.object({
+    projectId: z.string().uuid().optional(),
+    hostname: z.string().min(1)
+  })
+
+  const parsed = BodySchema.safeParse({
+    projectId: body.projectId,
+    hostname: (body.hostname as string | undefined) || (body.domain as string | undefined)
+  })
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'Invalid projectId or hostname' }, { status: 400 })
+  }
+
+  const { projectId, hostname } = parsed.data
 
   // Resolve project id
-  let pid = projectId as string | undefined
+  let pid: string | undefined = projectId
   if (!pid && legacyProjectSlug) {
     const { rows } = await query('select id from projects where slug=$1', [legacyProjectSlug])
     pid = rows[0]?.id
   }
-  if (!pid || !hostname) return NextResponse.json({ error: 'projectId and hostname required' }, { status: 400 })
+  if (!pid) {
+    return NextResponse.json({ error: 'projectId required' }, { status: 400 })
+  }
 
   await query(
     `insert into domains(project_id, domain)
@@ -38,6 +56,9 @@ export async function POST(req: NextRequest) {
 
   const { rows } = await query('select id, domain, status, token from domains where domain=$1', [hostname])
   const row = rows[0]
+  if (!row) {
+    return NextResponse.json({ error: 'Domain not found' }, { status: 404 })
+  }
 
   const instructions = [
     `Create TXT _verify.${hostname} with value: ${row.token}`,


### PR DESCRIPTION
## Summary
- validate `projectId` and `hostname` with Zod before database access
- return 400 on invalid input and 404 when the domain is missing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors across project)*

------
https://chatgpt.com/codex/tasks/task_e_68add6701c0883238a73bc769c814f7a