### PR TITLE
Sanitize site HTML and CSS with DOMPurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "seed:templates": "tsx scripts/seed-landing-templates.ts"
+    "seed:templates": "tsx scripts/seed-landing-templates.ts",
+    "test": "tsx --test"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",
@@ -30,7 +31,9 @@
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-resizable-panels": "^3.0.5",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "dompurify": "^3.0.8",
+    "jsdom": "^24.1.0"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/_sites/[site]/page.tsx
+++ b/src/app/_sites/[site]/page.tsx
@@ -1,4 +1,5 @@
 import { query } from '@/lib/db'
+import { sanitizeHtml, sanitizeCss } from '@/lib/sanitize'
 
 export const dynamic = 'force-dynamic'
 
@@ -12,12 +13,16 @@ export default async function Site({ params }: { params: { site: string } }) {
   `, [site])
   const html = rows[0]?.html || '<h1>Not published yet</h1>'
   const css = rows[0]?.css || ''
+  const sanitizedHtml = sanitizeHtml(html)
+  const sanitizedCss = sanitizeCss(css)
 
   return (
     <html>
-      <head><style dangerouslySetInnerHTML={{ __html: css }} /></head>
+      <head>
+        <style dangerouslySetInnerHTML={{ __html: sanitizedCss }} />
+      </head>
       <body>
-        <div dangerouslySetInnerHTML={{ __html: html }} />
+        <div dangerouslySetInnerHTML={{ __html: sanitizedHtml }} />
       </body>
     </html>
   )

--- a/src/lib/sanitize.test.ts
+++ b/src/lib/sanitize.test.ts
@@ -1,0 +1,22 @@
+import assert from 'node:assert'
+import { describe, it } from 'node:test'
+
+import { sanitizeHtml, sanitizeCss } from './sanitize'
+
+describe('sanitizeHtml', () => {
+  it('removes scripts and event handlers', () => {
+    const dirty = '<img src=x onerror="alert(1)"><script>alert(1)</script>'
+    const clean = sanitizeHtml(dirty)
+    assert(!clean.includes('script'))
+    assert(!clean.includes('onerror'))
+  })
+})
+
+describe('sanitizeCss', () => {
+  it('strips script tags', () => {
+    const dirty = 'body { color: red; }<script>alert(1)</script>'
+    const clean = sanitizeCss(dirty)
+    assert(!clean.includes('script'))
+  })
+})
+

--- a/src/lib/sanitize.ts
+++ b/src/lib/sanitize.ts
@@ -1,0 +1,14 @@
+import createDOMPurify from 'dompurify'
+import { JSDOM } from 'jsdom'
+
+const window = new JSDOM('').window
+const DOMPurify = createDOMPurify(window)
+
+export function sanitizeHtml(value: string) {
+  return DOMPurify.sanitize(value)
+}
+
+export function sanitizeCss(value: string) {
+  return DOMPurify.sanitize(value)
+}
+


### PR DESCRIPTION
## Summary
- sanitize published HTML and CSS using DOMPurify utilities
- add basic XSS unit tests for HTML and CSS content

## Testing
- `npm test` *(fails: tsx not found)*
- `npm run lint` *(fails: cannot find package '@eslint/eslintrc')*


------
https://chatgpt.com/codex/tasks/task_e_68add66e0be483239f5c5f9d4b8d3bbb