### PR TITLE
feat: add typed GrapesJS editor interface

### DIFF
--- a/src/components/builder/CanvasHost.tsx
+++ b/src/components/builder/CanvasHost.tsx
@@ -1,10 +1,10 @@
 'use client';
 
 import React, { useEffect, useRef } from 'react';
-import grapesjs, { Editor } from 'grapesjs';
-// (tuỳ bạn có dùng preset nào, có thể giữ hoặc bỏ 2 dòng dưới)
-// @ts-ignore – một số preset chưa có type
+import grapesjs from 'grapesjs';
 import presetWebpage from 'grapesjs-preset-webpage';
+import logger from '@/lib/logger';
+import { GrapesJSEditor } from '@/types/grapesjs-editor';
 
 type CanvasHostProps = {
   // có thể truyền thêm props nếu bạn đang dùng (projectId, pageId,…)
@@ -20,13 +20,13 @@ export default function CanvasHost({ className }: CanvasHostProps) {
   const assetsRef = useRef<HTMLDivElement | null>(null);
   const stylesRef = useRef<HTMLDivElement | null>(null);
 
-  const editorRef = useRef<Editor | null>(null);
+  const editorRef = useRef<GrapesJSEditor | null>(null);
 
   useEffect(() => {
     if (!canvasRef.current) return;
 
     // Khởi tạo editor
-    const editor = grapesjs.init({
+    const editor: GrapesJSEditor = grapesjs.init({
       container: canvasRef.current,
       height: '100%',
       width: '100%',
@@ -51,18 +51,15 @@ export default function CanvasHost({ className }: CanvasHostProps) {
     // @ts-ignore
     window.__gjs = editor;
 
-    const log = (msg: string) => console.log(msg);
-
-    const mountManagers = () => {
+    const mountManagers = (): void => {
       // BLOCKS
       try {
         const el = blocksRef.current;
         if (el) {
           el.innerHTML = '';
           const view = editor.BlockManager.render();
-          // @ts-ignore view.el tồn tại vì là Backbone view
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
-          log('[GrapesJS] Block Manager mounted');
+          if (view && view.el) el.appendChild(view.el);
+          logger.info('[GrapesJS] Block Manager mounted');
         } else {
           console.warn('[GrapesJS] Blocks element not available');
         }
@@ -76,9 +73,8 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.LayerManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
-          log('[GrapesJS] Layer Manager mounted');
+          if (view && view.el) el.appendChild(view.el);
+          logger.info('[GrapesJS] Layer Manager mounted');
         } else {
           console.warn('[GrapesJS] Layers element not available');
         }
@@ -92,11 +88,9 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           // Pages API mới – render() trả Backbone view giống các manager khác
-          // @ts-ignore
           const view = editor.Pages.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
-          log('[GrapesJS] Pages Manager mounted');
+          if (view && view.el) el.appendChild(view.el);
+          logger.info('[GrapesJS] Pages Manager mounted');
         } else {
           console.warn('[GrapesJS] Pages element not available');
         }
@@ -110,9 +104,8 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.AssetManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
-          log('[GrapesJS] Assets Manager mounted');
+          if (view && view.el) el.appendChild(view.el);
+          logger.info('[GrapesJS] Assets Manager mounted');
         } else {
           console.warn('[GrapesJS] Assets element not available');
         }
@@ -126,9 +119,8 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.StyleManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
-          log('[GrapesJS] Style Manager mounted');
+          if (view && view.el) el.appendChild(view.el);
+          logger.info('[GrapesJS] Style Manager mounted');
         } else {
           console.warn('[GrapesJS] StyleManager element not available');
         }
@@ -139,7 +131,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
 
     // Chờ editor load xong rồi mount managers
     editor.on('load', () => {
-      log('GrapesJS editor initialized successfully');
+      logger.info('GrapesJS editor initialized successfully');
       // Đảm bảo DOM panels đã render
       requestAnimationFrame(mountManagers);
     });

--- a/src/components/builder/GlobalStylesPanel.tsx
+++ b/src/components/builder/GlobalStylesPanel.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import { GrapesJSEditor } from '@/types/grapesjs-editor'
 
 interface GlobalStylesState {
   colors: {
@@ -49,7 +50,7 @@ const defaultStyles: GlobalStylesState = {
 interface GlobalStylesPanelProps {
   isOpen: boolean
   onClose: () => void
-  editor?: any
+  editor?: GrapesJSEditor
 }
 
 export default function GlobalStylesPanel({ isOpen, onClose, editor }: GlobalStylesPanelProps) {

--- a/src/components/builder/Topbar.tsx
+++ b/src/components/builder/Topbar.tsx
@@ -2,13 +2,14 @@
 
 import { useState, useEffect } from 'react'
 import PublishModal from './PublishModal'
+import { GrapesJSEditor } from '@/types/grapesjs-editor'
 
 export default function Topbar() {
   const [currentDevice, setCurrentDevice] = useState<'desktop' | 'tablet' | 'mobile'>('desktop')
   const [isPreview, setIsPreview] = useState(false)
   const [canUndo, setCanUndo] = useState(false)
   const [canRedo, setCanRedo] = useState(false)
-  const [editor, setEditor] = useState<any>(null)
+  const [editor, setEditor] = useState<GrapesJSEditor | null>(null)
   const [showPublishModal, setShowPublishModal] = useState(false)
 
   const deviceSizes = [
@@ -19,7 +20,7 @@ export default function Topbar() {
 
   useEffect(() => {
     // Listen for GrapesJS ready event
-    const handleGjsReady = (event: CustomEvent) => {
+    const handleGjsReady = (event: CustomEvent<GrapesJSEditor>) => {
       const editorInstance = event.detail
       setEditor(editorInstance)
 
@@ -58,7 +59,7 @@ export default function Topbar() {
     }
   }, [editor])
 
-  const updateHistoryState = (editorInstance: any) => {
+  const updateHistoryState = (editorInstance: GrapesJSEditor): void => {
     const undoManager = editorInstance.UndoManager
     setCanUndo(undoManager.hasUndo())
     setCanRedo(undoManager.hasRedo())

--- a/src/lib/gjs/assets.ts
+++ b/src/lib/gjs/assets.ts
@@ -2,6 +2,7 @@
  * GrapesJS Assets Manager configuration
  * Manages the media library and sample assets
  */
+import { GrapesJSEditor } from '@/types/grapesjs-editor'
 
 /**
  * Sample assets configuration
@@ -213,7 +214,7 @@ export const fallbackAssets = [
  * Configure and populate the Assets Manager
  * @param editor - The GrapesJS editor instance
  */
-export function configureAssets(editor: any): void {
+export function configureAssets(editor: GrapesJSEditor): void {
   if (!editor) {
     console.warn('Editor instance not provided to configureAssets')
     return
@@ -232,16 +233,18 @@ export function configureAssets(editor: any): void {
     assetManager.add(assetsToAdd)
 
     // Configure asset manager behavior
-    editor.on('asset:add', (asset: any) => {
-      console.log('Asset added:', asset.get('src'))
+    editor.on('asset:add', (asset: unknown) => {
+      if (asset && typeof (asset as { get?: (key: string) => unknown }).get === 'function') {
+        console.log('Asset added:', (asset as { get: (key: string) => unknown }).get('src'))
+      }
     })
 
     // Configure drag and drop for assets
-    editor.on('canvas:dragover', (e: any) => {
+    editor.on('canvas:dragover', (e: unknown) => {
       e.preventDefault()
     })
 
-    editor.on('canvas:drop', (e: any) => {
+    editor.on('canvas:drop', (e: unknown) => {
       e.preventDefault()
       // Handle file drops here if needed
     })

--- a/src/lib/gjs/blocks.ts
+++ b/src/lib/gjs/blocks.ts
@@ -2,6 +2,7 @@
  * GrapesJS Blocks configuration
  * Registers custom block categories and components for the visual editor
  */
+import { GrapesJSEditor } from '@/types/grapesjs-editor'
 
 /**
  * Block categories configuration
@@ -345,7 +346,7 @@ export const blocksToRemove = [
  * Register custom blocks and configure the Block Manager
  * @param editor - The GrapesJS editor instance
  */
-export function registerBlocks(editor: any): void {
+export function registerBlocks(editor: GrapesJSEditor): void {
   if (!editor) {
     console.warn('Editor instance not provided to registerBlocks')
     return
@@ -363,7 +364,7 @@ export function registerBlocks(editor: any): void {
     blocksToRemove.forEach((blockId: string) => {
       try {
         blockManager.remove?.(blockId)
-      } catch (e) {
+      } catch {
         // Ignore errors when removing non-existent blocks
       }
     })
@@ -372,7 +373,7 @@ export function registerBlocks(editor: any): void {
     // Categories will be created automatically when blocks are added with category property
 
     // Add custom blocks - categories will be created automatically
-    customBlocks.forEach((block: any) => {
+    customBlocks.forEach((block: unknown) => {
       try {
         blockManager.add(block.id, {
           label: block.label,

--- a/src/lib/gjs/panels.ts
+++ b/src/lib/gjs/panels.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import type { Editor } from 'grapesjs'
+import { GrapesJSEditor } from '@/types/grapesjs-editor'
 /**
  * GrapesJS Panels and Commands configuration
  * Configures topbar buttons and their corresponding commands
@@ -31,7 +32,7 @@ export const deviceConfigs = {
  * Configure panels and commands for the GrapesJS editor
  * @param editor - The GrapesJS editor instance
  */
-export function applyPanels(editor: any): void {
+export function applyPanels(editor: GrapesJSEditor): void {
   if (!editor) {
     console.warn('Editor instance not provided to applyPanels')
     return
@@ -48,7 +49,7 @@ export function applyPanels(editor: any): void {
 
     // Add device switching commands (updated for new device names)
     commands.add('set-device-desktop', {
-      run: (editor: any) => {
+      run: (editor: GrapesJSEditor) => {
         editor.setDevice('Desktop')
         // Dispatch event for UI sync
         window.dispatchEvent(new CustomEvent('gjs-device-change', {
@@ -58,7 +59,7 @@ export function applyPanels(editor: any): void {
     })
 
     commands.add('set-device-tablet', {
-      run: (editor: any) => {
+      run: (editor: GrapesJSEditor) => {
         editor.setDevice('Tablet')
         window.dispatchEvent(new CustomEvent('gjs-device-change', {
           detail: { device: 'tablet' }
@@ -67,7 +68,7 @@ export function applyPanels(editor: any): void {
     })
 
     commands.add('set-device-mobile', {
-      run: (editor: any) => {
+      run: (editor: GrapesJSEditor) => {
         editor.setDevice('Mobile')
         window.dispatchEvent(new CustomEvent('gjs-device-change', {
           detail: { device: 'mobile' }
@@ -77,7 +78,7 @@ export function applyPanels(editor: any): void {
 
     // Enhanced preview command with event dispatch
     commands.add('preview', {
-      run: (editor: any) => {
+      run: (editor: GrapesJSEditor) => {
         editor.runCommand('sw-visibility')
         window.dispatchEvent(new CustomEvent('gjs-preview-toggle', {
           detail: { isPreview: !editor.Canvas.getBody().classList.contains('gjs-dashed') }
@@ -87,7 +88,7 @@ export function applyPanels(editor: any): void {
 
     // Fullscreen command
     commands.add('fullscreen', {
-      run: (editor: any) => {
+      run: (editor: GrapesJSEditor) => {
         const canvas = editor.Canvas.getElement() as HTMLElement & {
           webkitRequestFullscreen?: () => void
           msRequestFullscreen?: () => void
@@ -110,7 +111,7 @@ export function applyPanels(editor: any): void {
 
     // Clear canvas command
     commands.add('clear-canvas', {
-      run: (editor: any) => {
+      run: (editor: GrapesJSEditor) => {
         if (confirm('Are you sure you want to clear the canvas? This action cannot be undone.')) {
           editor.setComponents('')
           editor.setStyle('')
@@ -120,14 +121,14 @@ export function applyPanels(editor: any): void {
 
     // Enhanced undo/redo commands with event dispatch
     commands.add('core:undo', {
-      run: (editor: any) => {
+      run: (editor: GrapesJSEditor) => {
         editor.UndoManager.undo()
         window.dispatchEvent(new CustomEvent('gjs-history-change'))
       }
     })
 
     commands.add('core:redo', {
-      run: (editor: any) => {
+      run: (editor: GrapesJSEditor) => {
         editor.UndoManager.redo()
         window.dispatchEvent(new CustomEvent('gjs-history-change'))
       }
@@ -227,12 +228,16 @@ export function applyPanels(editor: any): void {
 }
 
 // 'use client' optional for modules used on the client
-function resolveViewEl(view: any): HTMLElement | null {
+function resolveViewEl(view: unknown): HTMLElement | null {
   if (!view) return null
-  if ((view as any).el) return (view as any).el
-  if (typeof (view as any).get === 'function') {
-    const v = (view as any).get('el')
-    if (v instanceof HTMLElement) return v
+  if (typeof view === 'object' && view !== null) {
+    const maybeEl = (view as { el?: unknown }).el
+    if (maybeEl instanceof HTMLElement) return maybeEl
+    const getter = (view as { get?: (key: string) => unknown }).get
+    if (typeof getter === 'function') {
+      const v = getter('el')
+      if (v instanceof HTMLElement) return v
+    }
   }
   return view instanceof HTMLElement ? view : null
 }

--- a/src/lib/gjs/styles.ts
+++ b/src/lib/gjs/styles.ts
@@ -7,7 +7,7 @@ export interface StyleSector {
   name: string
   open?: boolean
   buildProps?: string[]
-  properties?: any[]
+  properties?: unknown[]
 }
 
 /**
@@ -270,11 +270,14 @@ function toKebab(v?: string): string {
   return (v || '').toLowerCase().trim().replace(/\s+/g, '-');
 }
 
+import { GrapesJSEditor } from '@/types/grapesjs-editor'
+
 /**
  * Apply the style manager configuration to the GrapesJS editor
  * @param editor - The GrapesJS editor instance
  */
-export function applyStyleManager(editor: any): void {
+
+export function applyStyleManager(editor: GrapesJSEditor): void {
   if (!editor) {
     console.warn('Editor instance not provided to applyStyleManager')
     return
@@ -282,7 +285,7 @@ export function applyStyleManager(editor: any): void {
 
   try {
     // Get the Style Manager with fallback for different API versions
-    const sm = (editor as any).Styles || (editor as any).StyleManager
+    const sm = editor.Styles || editor.StyleManager
 
     if (!sm) {
       console.warn('Style Manager not found in editor - styles configuration skipped')
@@ -331,7 +334,7 @@ export function applyStyleManager(editor: any): void {
 
           // Add properties individually if they exist
           if (Array.isArray(props) && typeof sm.addProperty === 'function') {
-            props.forEach((prop: any) => {
+            props.forEach((prop: unknown) => {
               try {
                 if (typeof prop === 'string') {
                   // Simple property name (buildProps style)

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,7 @@
+const logger = {
+  info: (...args: unknown[]) => console.info(...args),
+  warn: (...args: unknown[]) => console.warn(...args),
+  error: (...args: unknown[]) => console.error(...args),
+};
+
+export default logger;

--- a/src/types/grapesjs-editor.ts
+++ b/src/types/grapesjs-editor.ts
@@ -1,0 +1,38 @@
+export interface ViewLike {
+  el?: HTMLElement;
+}
+
+export interface ManagerLike {
+  render(): ViewLike;
+  getView?(): ViewLike;
+  addSectors?(sectors: unknown): void;
+  addSector?(id: string, opts: unknown): void;
+  addProperty?(sectorId: string, property: unknown): void;
+  getSectors?(): { reset?(): void } | undefined;
+}
+
+export interface CanvasLike {
+  getDocument(): Document | null;
+}
+
+export interface UndoManagerLike {
+  hasUndo(): boolean;
+  hasRedo(): boolean;
+}
+
+export interface GrapesJSEditor {
+  BlockManager: ManagerLike;
+  LayerManager: ManagerLike;
+  Pages: ManagerLike;
+  AssetManager: ManagerLike;
+  StyleManager: ManagerLike;
+  TraitManager: ManagerLike;
+  Styles?: ManagerLike;
+  Canvas: CanvasLike;
+  UndoManager: UndoManagerLike;
+  on(event: string, callback: (...args: unknown[]) => void): void;
+  runCommand(command: string): void;
+  destroy(): void;
+  isLoaded?(): boolean;
+  getModel?(): unknown;
+}

--- a/src/types/grapesjs-tabs.d.ts
+++ b/src/types/grapesjs-tabs.d.ts
@@ -1,5 +1,5 @@
 declare module 'grapesjs-tabs' {
-  const plugin: any;
+  const plugin: unknown;
   export default plugin;
 }
 


### PR DESCRIPTION
## Summary
- define `GrapesJSEditor` interface for shared editor typings
- replace `any` editor usage and clean up console logging
- add simple logger utility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68add66bdb108323b494fc604a7130ea