### PR TITLE
refactor: replace console logs with structured logger

### DIFF
--- a/src/app/api/publish/route.ts
+++ b/src/app/api/publish/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { getPageData } from '@/lib/db'
 import { mkdir, writeFile } from 'fs/promises'
 import { join } from 'path'
+import { logger } from '@/lib/logger'
 
 export async function POST(request: NextRequest) {
   try {
@@ -15,7 +16,7 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    console.log(`Publishing ${project}/${page}...`)
+    logger.info('Publishing page', { project, page })
 
     // Get page data from database
     const pageData = await getPageData(project, page)
@@ -48,7 +49,7 @@ export async function POST(request: NextRequest) {
       // Generate deployment URL
       const deploymentUrl = `/sites/${project}/${filename}`
 
-      console.log(`Published successfully: ${deploymentUrl}`)
+      logger.info('Published successfully', { deploymentUrl })
 
       return NextResponse.json({
         success: true,
@@ -63,7 +64,7 @@ export async function POST(request: NextRequest) {
         }
       })
     } catch (fsError) {
-      console.error('File system error:', fsError)
+      logger.error('File system error', { error: fsError })
       return NextResponse.json(
         { error: 'Failed to write published file' },
         { status: 500 }
@@ -71,7 +72,7 @@ export async function POST(request: NextRequest) {
     }
 
   } catch (error) {
-    console.error('Error in POST /api/publish:', error)
+    logger.error('Error in POST /api/publish', { error })
     return NextResponse.json(
       { 
         error: 'Failed to publish page',
@@ -160,20 +161,11 @@ function generateHTMLDocument(
       });
     });
     
-    // Add click handlers for buttons without hrefs
-    document.querySelectorAll('button, .btn').forEach(btn => {
-      if (!btn.getAttribute('href') && !btn.getAttribute('onclick')) {
-        btn.addEventListener('click', function() {
-          console.log('Button clicked:', this.textContent);
-        });
-      }
-    });
   </script>
-  
+
   <!-- Analytics placeholder -->
   <script>
-    console.log('Page loaded: ${pageTitle} - ${projectName}');
-    console.log('Published at: ${new Date().toISOString()}');
+    // Add analytics scripts here
   </script>
 </body>
 </html>`

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,10 @@
+export type LogMeta = Record<string, unknown>
+
+export const logger = {
+  info: (message: string, meta: LogMeta = {}) => {
+    console.info(JSON.stringify({ level: 'info', message, ...meta }))
+  },
+  error: (message: string, meta: LogMeta = {}) => {
+    console.error(JSON.stringify({ level: 'error', message, ...meta }))
+  }
+}


### PR DESCRIPTION
## Summary
- add lightweight structured logger utility
- replace console.log calls in publish route with structured logging
- remove console logs from generated HTML and leave analytics placeholder

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 67 problems)*
- `npx eslint src/app/api/publish/route.ts src/lib/logger.ts`


------
https://chatgpt.com/codex/tasks/task_e_68add667be40832383d9645b95ed75ae