### PR TITLE
feat: add GrapesJS typings and remove ignores

### DIFF
--- a/src/components/builder/CanvasHost.tsx
+++ b/src/components/builder/CanvasHost.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useRef } from 'react';
 import grapesjs, { Editor } from 'grapesjs';
 // (tuỳ bạn có dùng preset nào, có thể giữ hoặc bỏ 2 dòng dưới)
-// @ts-ignore – một số preset chưa có type
 import presetWebpage from 'grapesjs-preset-webpage';
 
 type CanvasHostProps = {
@@ -48,7 +47,6 @@ export default function CanvasHost({ className }: CanvasHostProps) {
 
     editorRef.current = editor;
     // Expose để debug
-    // @ts-ignore
     window.__gjs = editor;
 
     const log = (msg: string) => console.log(msg);
@@ -60,8 +58,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.BlockManager.render();
-          // @ts-ignore view.el tồn tại vì là Backbone view
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Block Manager mounted');
         } else {
           console.warn('[GrapesJS] Blocks element not available');
@@ -76,8 +73,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.LayerManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Layer Manager mounted');
         } else {
           console.warn('[GrapesJS] Layers element not available');
@@ -92,10 +88,8 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           // Pages API mới – render() trả Backbone view giống các manager khác
-          // @ts-ignore
           const view = editor.Pages.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Pages Manager mounted');
         } else {
           console.warn('[GrapesJS] Pages element not available');
@@ -110,8 +104,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.AssetManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Assets Manager mounted');
         } else {
           console.warn('[GrapesJS] Assets element not available');
@@ -126,8 +119,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.StyleManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Style Manager mounted');
         } else {
           console.warn('[GrapesJS] StyleManager element not available');
@@ -149,7 +141,6 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         editor.destroy();
       } catch {}
       editorRef.current = null;
-      // @ts-ignore
       if (window.__gjs === editor) delete window.__gjs;
     };
   }, []);

--- a/src/types/grapesjs.d.ts
+++ b/src/types/grapesjs.d.ts
@@ -1,0 +1,61 @@
+declare module 'grapesjs' {
+  export interface View {
+    el: HTMLElement
+  }
+
+  export interface BlockManager {
+    render(): View
+  }
+
+  export interface LayerManager {
+    render(): View
+  }
+
+  export interface AssetManager {
+    render(): View
+  }
+
+  export interface StyleManager {
+    render(): View
+  }
+
+  export interface Pages {
+    render(): View
+  }
+
+  export interface Editor {
+    BlockManager: BlockManager
+    LayerManager: LayerManager
+    AssetManager: AssetManager
+    StyleManager: StyleManager
+    Pages: Pages
+    on(event: string, callback: (...args: unknown[]) => void): void
+    destroy(): void
+  }
+
+  export interface EditorConfig {
+    container: HTMLElement
+    height?: string | number
+    width?: string | number
+    [key: string]: unknown
+  }
+
+  export function init(config: EditorConfig): Editor
+
+  const grapesjs: { init: typeof init }
+  export default grapesjs
+}
+
+declare module 'grapesjs-preset-webpage' {
+  import type { Editor } from 'grapesjs'
+  const plugin: (editor: Editor, options?: Record<string, unknown>) => void
+  export default plugin
+}
+
+declare global {
+  interface Window {
+    __gjs?: import('grapesjs').Editor
+  }
+}
+
+export {}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     ],
     "paths": {
       "@/*": ["./src/*"]
-    }
+    },
+    "typeRoots": ["./src/types", "./node_modules/@types"]
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- add local GrapesJS type declarations and global `window.__gjs`
- type CanvasHost manager rendering and drop `@ts-ignore`
- configure tsconfig to resolve local types

## Testing
- `npx eslint src/components/builder/CanvasHost.tsx src/types/grapesjs.d.ts`
- `npx tsc --noEmit` *(fails: Cannot find type definition file for 'backbone', 'file-saver', 'jquery', 'pg', 'sizzle', 'underscore')*

------
https://chatgpt.com/codex/tasks/task_e_68add65c91c48323a5819ea02412088f