### PR TITLE
chore: replace deprecated substr usage

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -90,7 +90,7 @@ export function listWorkspaces(): Workspace[] {
 
 export function createWorkspace(name: string): Workspace {
   const workspace: Workspace = {
-    id: `ws-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    id: `ws-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
     name,
     role: 'owner',
     createdAt: Date.now(),
@@ -150,7 +150,7 @@ export function createProject(data: {
   thumb?: string;
 }): Project {
   const project: Project = {
-    id: `proj-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    id: `proj-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
     workspaceId: data.workspaceId,
     name: data.name,
     slug: data.slug,


### PR DESCRIPTION
## Summary
- use `slice` instead of deprecated `substr` when generating workspace and project IDs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any. Specify a different type)*


------
https://chatgpt.com/codex/tasks/task_e_68add60a07ec832395427ece36c3f257