### PR TITLE
Add Jest testing setup and home page test

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ You can start editing the page by modifying `app/page.tsx`. The page auto-update
 
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
+## Running Tests
+
+Execute the test suite with:
+
+```bash
+npm test
+```
+
 ## Learn More
 
 To learn more about Next.js, take a look at the following resources:

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jsdom',
+};
+
+module.exports = createJestConfig(customJestConfig);

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "jest"
   },
   "dependencies": {
     "react": "19.1.0",
@@ -22,6 +23,10 @@
     "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.0",
-    "@eslint/eslintrc": "^3"
+    "@eslint/eslintrc": "^3",
+    "jest": "^29",
+    "@testing-library/react": "^14",
+    "@testing-library/jest-dom": "^6",
+    "@types/jest": "^29"
   }
 }

--- a/src/app/page.test.tsx
+++ b/src/app/page.test.tsx
@@ -1,0 +1,7 @@
+import { render, screen } from '@testing-library/react';
+import Home from './page';
+
+test('home page renders without crashing', () => {
+  render(<Home />);
+  expect(screen.getByText('Get started by editing')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- configure Jest with jsdom and React Testing Library
- add sample test for home page
- document how to run tests

## Testing
- `npm test` *(fails: jest not found - package installation blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68add5bf43708323a09b0bae1985efb9