### PR TITLE
refactor: update RootLayout ReactNode type

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import type { ReactNode } from "react";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -20,7 +21,7 @@ export const metadata: Metadata = {
 export default function RootLayout({
   children,
 }: Readonly<{
-  children: React.ReactNode;
+  children: ReactNode;
 }>) {
   return (
     <html lang="en">


### PR DESCRIPTION
## Summary
- import ReactNode in RootLayout
- use ReactNode type for children prop

## Testing
- `npm run lint`
- `npx tsc --noEmit`
- `npm run build` *(fails: Failed to fetch Geist fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68add5bdac788323933e616717363bb2