### PR TITLE
refactor: use slice for ID generation

### DIFF
--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -90,7 +90,7 @@ export function listWorkspaces(): Workspace[] {
 
 export function createWorkspace(name: string): Workspace {
   const workspace: Workspace = {
-    id: `ws-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    id: `ws-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
     name,
     role: 'owner',
     createdAt: Date.now(),
@@ -150,7 +150,7 @@ export function createProject(data: {
   thumb?: string;
 }): Project {
   const project: Project = {
-    id: `proj-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
+    id: `proj-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`,
     workspaceId: data.workspaceId,
     name: data.name,
     slug: data.slug,

--- a/tests/store.test.ts
+++ b/tests/store.test.ts
@@ -1,0 +1,19 @@
+import assert from 'node:assert';
+
+import { createWorkspace, createProject } from '../src/lib/store';
+
+// Ensure workspace IDs include a 9-character random segment
+const workspace = createWorkspace('Test Workspace');
+const workspaceRandom = workspace.id.split('-').pop()!;
+assert.strictEqual(workspaceRandom.length, 9);
+
+// Ensure project IDs include a 9-character random segment
+const project = createProject({
+  workspaceId: workspace.id,
+  name: 'Test Project',
+  slug: 'test-project',
+  status: 'draft',
+});
+const projectRandom = project.id.split('-').pop()!;
+assert.strictEqual(projectRandom.length, 9);
+


### PR DESCRIPTION
## Summary
- replace deprecated `substr` with `slice` for workspace and project IDs
- add tests ensuring generated IDs include a 9-character random segment

## Testing
- `npx tsx tests/store.test.ts`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68add4c624bc8323881e884d62e35cdd