### PR TITLE
Gracefully close DB pool after seeding templates

### DIFF
--- a/scripts/seed-landing-templates.ts
+++ b/scripts/seed-landing-templates.ts
@@ -3,7 +3,7 @@ import * as dotenv from 'dotenv'
 import path from 'node:path'
 dotenv.config({ path: path.resolve(process.cwd(), '.env.local') })
 
-import { getPool } from '../src/lib/db'
+import { getPool, closePool } from '../src/lib/db'
 
 const previews = [
   '/demo/0b64e28e-8942-4ffe-8102-7cf7d491ca17.png',
@@ -52,7 +52,9 @@ async function run() {
     )
   }
   console.log('Seeded templates:', templates.length)
-  process.exit(0)
+  await closePool()
 }
-
-run().catch(e => { console.error(e); process.exit(1) })
+run().catch(async (e) => {
+  console.error(e)
+  await closePool()
+})


### PR DESCRIPTION
## Summary
- Import and use `closePool` in `seed-landing-templates` to shut down the connection pool instead of calling `process.exit`
- Remove explicit `process.exit` calls so the script exits naturally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint -- scripts/seed-landing-templates.ts`


------
https://chatgpt.com/codex/tasks/task_e_68add492990483239929ed8f243c8431