### PR TITLE
chore: improve GrapesJS typings

### DIFF
--- a/src/components/builder/CanvasHost.tsx
+++ b/src/components/builder/CanvasHost.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useRef } from 'react';
 import grapesjs, { Editor } from 'grapesjs';
 // (tuỳ bạn có dùng preset nào, có thể giữ hoặc bỏ 2 dòng dưới)
-// @ts-ignore – một số preset chưa có type
 import presetWebpage from 'grapesjs-preset-webpage';
 
 type CanvasHostProps = {
@@ -48,7 +47,6 @@ export default function CanvasHost({ className }: CanvasHostProps) {
 
     editorRef.current = editor;
     // Expose để debug
-    // @ts-ignore
     window.__gjs = editor;
 
     const log = (msg: string) => console.log(msg);
@@ -60,8 +58,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.BlockManager.render();
-          // @ts-ignore view.el tồn tại vì là Backbone view
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Block Manager mounted');
         } else {
           console.warn('[GrapesJS] Blocks element not available');
@@ -76,8 +73,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.LayerManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Layer Manager mounted');
         } else {
           console.warn('[GrapesJS] Layers element not available');
@@ -92,10 +88,8 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           // Pages API mới – render() trả Backbone view giống các manager khác
-          // @ts-ignore
           const view = editor.Pages.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Pages Manager mounted');
         } else {
           console.warn('[GrapesJS] Pages element not available');
@@ -110,8 +104,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.AssetManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Assets Manager mounted');
         } else {
           console.warn('[GrapesJS] Assets element not available');
@@ -126,8 +119,7 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         if (el) {
           el.innerHTML = '';
           const view = editor.StyleManager.render();
-          // @ts-ignore
-          if (view && view.el) el.appendChild(view.el as HTMLElement);
+          if (view?.el) el.appendChild(view.el);
           log('[GrapesJS] Style Manager mounted');
         } else {
           console.warn('[GrapesJS] StyleManager element not available');
@@ -149,7 +141,6 @@ export default function CanvasHost({ className }: CanvasHostProps) {
         editor.destroy();
       } catch {}
       editorRef.current = null;
-      // @ts-ignore
       if (window.__gjs === editor) delete window.__gjs;
     };
   }, []);

--- a/src/types/grapesjs-preset-webpage.d.ts
+++ b/src/types/grapesjs-preset-webpage.d.ts
@@ -1,0 +1,5 @@
+import type { Editor } from 'grapesjs';
+
+declare module 'grapesjs-preset-webpage' {
+  export default function presetWebpage(editor: Editor, opts?: Record<string, unknown>): void;
+}

--- a/src/types/grapesjs-tabs.d.ts
+++ b/src/types/grapesjs-tabs.d.ts
@@ -1,5 +1,6 @@
+import type { Editor } from 'grapesjs';
+
 declare module 'grapesjs-tabs' {
-  const plugin: any;
-  export default plugin;
+  export default function tabs(editor: Editor, opts?: Record<string, unknown>): void;
 }
 

--- a/src/types/grapesjs.d.ts
+++ b/src/types/grapesjs.d.ts
@@ -1,0 +1,58 @@
+export interface GrapesView {
+  el: HTMLElement;
+}
+
+export interface BlockManager {
+  render(): GrapesView;
+}
+
+export interface LayerManager {
+  render(): GrapesView;
+}
+
+export interface AssetManager {
+  render(): GrapesView;
+}
+
+export interface StyleManager {
+  render(): GrapesView;
+}
+
+export interface Pages {
+  render(): GrapesView;
+}
+
+export interface Editor {
+  BlockManager: BlockManager;
+  LayerManager: LayerManager;
+  AssetManager: AssetManager;
+  StyleManager: StyleManager;
+  Pages: Pages;
+  on(event: string, callback: (...args: unknown[]) => void): void;
+  destroy(): void;
+}
+
+export interface InitConfig {
+  container: HTMLElement | string;
+  height?: string | number;
+  width?: string | number;
+  fromElement?: boolean;
+  storageManager?: unknown;
+  panels?: unknown;
+  deviceManager?: unknown;
+  plugins?: unknown[];
+  pluginsOpts?: Record<string, unknown>;
+}
+
+export function init(config: InitConfig): Editor;
+
+declare const grapesjs: {
+  init: typeof init;
+};
+export default grapesjs;
+
+declare global {
+  interface Window {
+    __gjs?: Editor;
+  }
+}


### PR DESCRIPTION
## Summary
- declare missing GrapesJS APIs and global editor handle
- add preset-webpage plugin typings
- clean up GrapesJS tabs stub and remove ignores in CanvasHost

## Testing
- `npx eslint src/components/builder/CanvasHost.tsx`
- `npx tsc --noEmit src/components/builder/CanvasHost.tsx` *(fails: Cannot find type definition file for 'backbone', 'file-saver', 'jquery', 'pg', 'sizzle', 'underscore')*


------
https://chatgpt.com/codex/tasks/task_e_68add48ff5208323b41119c722efc586