### PR TITLE
feat: sanitize html content

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "build": "next build --turbopack",
     "start": "next start",
     "lint": "eslint",
-    "seed:templates": "tsx scripts/seed-landing-templates.ts"
+    "seed:templates": "tsx scripts/seed-landing-templates.ts",
+    "test": "node --test"
   },
   "dependencies": {
     "@headlessui/react": "^2.2.7",

--- a/src/app/_sites/[site]/page.tsx
+++ b/src/app/_sites/[site]/page.tsx
@@ -1,4 +1,5 @@
 import { query } from '@/lib/db'
+import { sanitizeHtml, sanitizeCss } from '@/lib/sanitize.mjs'
 
 export const dynamic = 'force-dynamic'
 
@@ -10,8 +11,10 @@ export default async function Site({ params }: { params: { site: string } }) {
     where p.slug=$1
     order by pub.created_at desc limit 1
   `, [site])
-  const html = rows[0]?.html || '<h1>Not published yet</h1>'
-  const css = rows[0]?.css || ''
+  const rawHtml = rows[0]?.html || '<h1>Not published yet</h1>'
+  const rawCss = rows[0]?.css || ''
+  const html = sanitizeHtml(rawHtml)
+  const css = sanitizeCss(rawCss)
 
   return (
     <html>

--- a/src/lib/sanitize.mjs
+++ b/src/lib/sanitize.mjs
@@ -1,0 +1,37 @@
+
+// Simple regex-based sanitization as fallback when DOMPurify is unavailable.
+// Removes script tags, dangerous attributes, and disallowed tags.
+const ALLOWED_TAGS = ['a','b','i','em','strong','p','div','span','ul','ol','li','h1','h2','h3','h4','h5','h6','img','br'];
+const ALLOWED_ATTR = ['href','src','alt','title','style'];
+
+export function sanitizeHtml(html) {
+  // Remove script tags and content
+  let sanitized = html.replace(/<script[\s\S]*?>[\s\S]*?<\/script>/gi, '');
+  // Remove event handler attributes
+  sanitized = sanitized.replace(/\son\w+="[^"]*"/gi, '');
+  // Remove disallowed tags
+  sanitized = sanitized.replace(/<\/?([a-z][a-z0-9]*)\b[^>]*>/gi, (match, tag) => {
+    return ALLOWED_TAGS.includes(tag.toLowerCase()) ? match : '';
+  });
+  // Remove disallowed attributes
+  sanitized = sanitized.replace(/<([a-z][a-z0-9]*)([^>]*)>/gi, (match, tag, attrs) => {
+    const safeAttrs = attrs
+      .split(/\s+/)
+      .filter(attr => {
+        const eqIdx = attr.indexOf('=');
+        if (eqIdx === -1) return false;
+        const name = attr.slice(0, eqIdx).toLowerCase();
+        return ALLOWED_ATTR.includes(name);
+      })
+      .join(' ');
+    return `<${tag}${safeAttrs ? ' ' + safeAttrs : ''}>`;
+  });
+  return sanitized;
+}
+
+export function sanitizeCss(css) {
+  let sanitized = css.replace(/expression\s*\([^)]*\)/gi, '');
+  sanitized = sanitized.replace(/url\(\s*['"]?javascript:[^)]+\)/gi, '');
+  return sanitized;
+}
+

--- a/src/lib/sanitize.test.js
+++ b/src/lib/sanitize.test.js
@@ -1,0 +1,17 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { sanitizeHtml, sanitizeCss } from './sanitize.mjs';
+
+describe('sanitize', () => {
+  it('removes script tags from html', () => {
+    const dirty = '<div>ok</div><script>alert(1)</script>';
+    const clean = sanitizeHtml(dirty);
+    assert.equal(clean.includes('<script>'), false);
+  });
+
+  it('removes dangerous urls from css', () => {
+    const dirty = "body { background-image: url('javascript:alert(1)'); }";
+    const clean = sanitizeCss(dirty);
+    assert.equal(clean.includes('javascript:'), false);
+  });
+});


### PR DESCRIPTION
## Summary
- sanitize HTML and CSS before rendering
- whitelist permitted tags and attributes
- test that malicious script and URLs are removed

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any...)*

------
https://chatgpt.com/codex/tasks/task_e_68add48d2d68832380616156f97a1706