### PR TITLE
refactor: strengthen db typings

### DIFF
--- a/src/app/_sites/[site]/page.tsx
+++ b/src/app/_sites/[site]/page.tsx
@@ -4,7 +4,7 @@ export const dynamic = 'force-dynamic'
 
 export default async function Site({ params }: { params: { site: string } }) {
   const site = params.site
-  const { rows } = await query(`
+  const { rows } = await query<{ html: string | null; css: string | null }>(`
     select pub.html, pub.css from publications pub
     join projects p on p.id = pub.project_id
     where p.slug=$1

--- a/src/app/api/domains/[id]/verify/route.ts
+++ b/src/app/api/domains/[id]/verify/route.ts
@@ -5,6 +5,11 @@ import { query } from '@/lib/db'
 export async function POST(_req: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id } = await context.params
   await query('update domains set status=$2, verified_at=now() where id=$1', [id, 'active'])
-  const { rows } = await query('select id, domain, status, verified_at from domains where id=$1', [id])
+  const { rows } = await query<{
+    id: string
+    domain: string
+    status: string
+    verified_at: string | null
+  }>('select id, domain, status, verified_at from domains where id=$1', [id])
   return NextResponse.json({ status: rows[0]?.status || 'active' })
 }

--- a/src/app/api/domains/route.ts
+++ b/src/app/api/domains/route.ts
@@ -4,27 +4,36 @@ import { query } from '@/lib/db'
 export async function GET(req: NextRequest) {
   const url = new URL(req.url)
   const project = url.searchParams.get('project') || ''
-  const { rows } = await query(`
+  const { rows } = await query<{
+    id: string
+    domain: string
+    status: string
+    token: string
+    verified_at: string | null
+  }>(
+    `
     select d.id, d.domain, d.status, d.token, d.verified_at
     from domains d
     join projects p on p.id = d.project_id
     where p.slug=$1
     order by d.domain
-  `, [project])
+  `,
+    [project]
+  )
   return NextResponse.json(rows)
 }
 
 export async function POST(req: NextRequest) {
   const url = new URL(req.url)
   const legacyProjectSlug = url.searchParams.get('project') || ''
-  const body = await req.json().catch(() => ({} as any))
-  const projectId: string | undefined = body.projectId
-  const hostname: string | undefined = body.hostname || body.domain
+  const body = (await req.json().catch(() => ({}))) as Record<string, unknown>
+  const projectId: string | undefined = body.projectId as string | undefined
+  const hostname: string | undefined = (body.hostname || body.domain) as string | undefined
 
   // Resolve project id
   let pid = projectId as string | undefined
   if (!pid && legacyProjectSlug) {
-    const { rows } = await query('select id from projects where slug=$1', [legacyProjectSlug])
+    const { rows } = await query<{ id: string }>('select id from projects where slug=$1', [legacyProjectSlug])
     pid = rows[0]?.id
   }
   if (!pid || !hostname) return NextResponse.json({ error: 'projectId and hostname required' }, { status: 400 })
@@ -36,7 +45,12 @@ export async function POST(req: NextRequest) {
     [pid, hostname]
   )
 
-  const { rows } = await query('select id, domain, status, token from domains where domain=$1', [hostname])
+  const { rows } = await query<{
+    id: string
+    domain: string
+    status: string
+    token: string
+  }>('select id, domain, status, token from domains where domain=$1', [hostname])
   const row = rows[0]
 
   const instructions = [

--- a/src/app/api/projects/[id]/route.ts
+++ b/src/app/api/projects/[id]/route.ts
@@ -1,17 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { query } from '@/lib/db'
+import { query, Project, PageData } from '@/lib/db'
 
 export async function GET(_req: NextRequest, context: { params: Promise<{ id: string }> }) {
   const { id: idOrSlug } = await context.params
   // Try by UUID first, then by slug
-  const { rows: projRows } = await query(
+  const { rows: projRows } = await query<Project>(
     `select id, slug, name, created_at from projects where id::text=$1 or slug=$1 limit 1`,
     [idOrSlug]
   )
   const project = projRows[0]
   if (!project) return NextResponse.json({ error: 'Not found' }, { status: 404 })
 
-  const { rows: pages } = await query(
+  const { rows: pages } = await query<Pick<PageData, 'id' | 'slug' | 'updated_at'>>(
     `select id, slug, updated_at from pages where project_id=$1 order by updated_at desc`,
     [project.id]
   )

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { query } from '@/lib/db'
+import { query, GjsComponent, GjsStyle } from '@/lib/db'
 
 export async function GET(req: NextRequest) {
   const url = new URL(req.url)
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
   const tag = (url.searchParams.get('tag') || '').trim()
 
   const clauses: string[] = []
-  const params: any[] = []
+  const params: unknown[] = []
   if (q) { params.push(`%${q.toLowerCase()}%`); clauses.push(`lower(name) like $${params.length}`) }
   if (tag) { params.push(tag); clauses.push(`(meta->'tags')::jsonb ? $${params.length}`) }
 
@@ -32,8 +32,8 @@ export async function POST(req: NextRequest) {
   const g = grapesJson || {}
   const gHtml = (g['gjs-html'] as string) || ''
   const gCss = (g['gjs-css'] as string) || ''
-  const gComp = (g['gjs-components'] as object) || {}
-  const gStyles = (g['gjs-styles'] as object) || {}
+  const gComp = (g['gjs-components'] as GjsComponent[]) || []
+  const gStyles = (g['gjs-styles'] as GjsStyle[]) || []
 
   await query(
     `insert into templates(name, type, gjs_html, gjs_css, gjs_components, gjs_styles, meta)

--- a/src/app/api/tenants/route.ts
+++ b/src/app/api/tenants/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { query } from '@/lib/db'
+import { query, Tenant } from '@/lib/db'
 
 export async function GET() {
-  const { rows } = await query('select id, slug, name from tenants order by created_at desc')
+  const { rows } = await query<Tenant>('select id, slug, name from tenants order by created_at desc')
   return NextResponse.json(rows)
 }
 

--- a/src/app/api/usage/route.ts
+++ b/src/app/api/usage/route.ts
@@ -7,7 +7,7 @@ export async function GET(req: NextRequest) {
 
   let workspaceId: string | null = null
   if (workspace) {
-    const { rows } = await query('select id from tenants where slug=$1', [workspace])
+    const { rows } = await query<{ id: string }>('select id from tenants where slug=$1', [workspace])
     workspaceId = rows[0]?.id || null
   }
 
@@ -15,7 +15,7 @@ export async function GET(req: NextRequest) {
   const projectsLimit = 5
   const publishLimit = 20
 
-  const { rows: projRows } = await query(
+  const { rows: projRows } = await query<{ cnt: number }>(
     workspaceId
       ? 'select count(*)::int as cnt from projects where tenant_id=$1'
       : 'select count(*)::int as cnt from projects',
@@ -23,7 +23,7 @@ export async function GET(req: NextRequest) {
   )
   const projects = projRows[0]?.cnt ?? 0
 
-  const { rows: pubRows } = await query(
+  const { rows: pubRows } = await query<{ cnt: number }>(
     workspaceId
       ? `select count(*)::int as cnt from publications p
          join projects pr on pr.id=p.project_id where pr.tenant_id=$1`


### PR DESCRIPTION
## Summary
- tighten `query` helper to accept `unknown[]` params
- add GrapesJS component/style interfaces and remove `any` usage
- replace `page_count` cast with typed mapping and update callers

## Testing
- `npx tsc -p tsconfig.json` *(fails: Cannot find module 'lucide-react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68add44e18088323b5fc6acb3dc12732