### PR TITLE
refactor left dock types

### DIFF
--- a/src/components/builder/LeftDock.tsx
+++ b/src/components/builder/LeftDock.tsx
@@ -1,13 +1,20 @@
 'use client'
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
-import { useState, useEffect } from 'react'
+import { useState, useEffect, type ReactNode } from 'react'
+import type { Editor } from 'grapesjs'
 import GlobalStylesPanel from './GlobalStylesPanel'
+
+interface DockItem {
+  id: string
+  command?: string
+  label: string
+  icon: ReactNode
+  active: boolean
+}
 
 export default function LeftDock() {
   const [activePanel, setActivePanel] = useState<string>('pages-layers')
-  const [editor, setEditor] = useState<any>(null)
+  const [editor, setEditor] = useState<Editor | null>(null)
   const [showDrawer, setShowDrawer] = useState<boolean>(false)
   const [showGlobalStyles, setShowGlobalStyles] = useState<boolean>(false)
   const [drawerContent, setDrawerContent] = useState<{
@@ -17,7 +24,7 @@ export default function LeftDock() {
     panelElement?: HTMLElement
   } | null>(null)
 
-  const dockItems = [
+  const dockItems: DockItem[] = [
     {
       id: 'pages-layers',
       command: 'open-pages-layers',
@@ -101,7 +108,7 @@ export default function LeftDock() {
     }
   }, [])
 
-  const handleItemClick = (item: any) => {
+  const handleItemClick = (item: DockItem) => {
     if (editor && item.command) {
       // Set active panel
       setActivePanel(item.id)


### PR DESCRIPTION
## Summary
- remove explicit-any disable in LeftDock and add GrapesJS Editor typing
- define DockItem interface for left dock buttons
- type editor state and click handler

## Testing
- `npx eslint src/components/builder/LeftDock.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68add44b12988323a3cba500a963e4e6