### PR TITLE
Use Geist fonts in global styles

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -22,5 +22,10 @@
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: Arial, Helvetica, sans-serif;
+  /* Use the Geist font loaded via next/font with sensible fallbacks */
+  font-family: var(--font-sans), Arial, Helvetica, sans-serif;
+}
+
+code, pre {
+  font-family: var(--font-mono), ui-monospace, monospace;
 }


### PR DESCRIPTION
## Summary
- use `Geist` font variables in global styles
- ensure monospace elements use `Geist Mono` with fallbacks

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch `Geist` and `Geist Mono` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68add380f2bc83239479ff96092fab53