### PR TITLE
Add Workspace interface and type AppShell workspace state

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import Link from 'next/link'
 import { useRouter } from 'next/navigation'
 import { listWorkspaces, getWorkspace } from '../lib/store'
+import type { Workspace } from '@/types/workspace'
 import Button from './ui/Button'
 import Dropdown from './ui/Dropdown'
 
@@ -16,7 +17,7 @@ const CURRENT_WORKSPACE_KEY = 'currentWS'
 const AppShell = ({ children }: AppShellProps) => {
   const router = useRouter()
   const workspaces = listWorkspaces()
-  const [currentWorkspace, setCurrentWorkspace] = useState<any>(null) // Initialize as null to prevent hydration mismatch
+  const [currentWorkspace, setCurrentWorkspace] = useState<Workspace | null>(null) // Initialize as null to prevent hydration mismatch
   const [isClient, setIsClient] = useState(false)
 
   // Load current workspace from localStorage on mount
@@ -44,7 +45,7 @@ const AppShell = ({ children }: AppShellProps) => {
   }, [workspaces])
 
   // Handle workspace selection
-  const handleWorkspaceSelect = (workspace: any) => {
+  const handleWorkspaceSelect = (workspace: Workspace) => {
     setCurrentWorkspace(workspace)
     localStorage.setItem(CURRENT_WORKSPACE_KEY, workspace.id)
     router.push('/projects') // Navigate to projects page to show updated workspace content

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,4 +1,5 @@
-import { Workspace, Project, ProjectStatus } from './types';
+import type { Workspace } from '@/types/workspace';
+import { Project, ProjectStatus } from './types';
 
 // Storage keys
 const STORAGE_KEY_WORKSPACES = 'designer-workspaces';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,9 +1,4 @@
-export type Workspace = {
-  id: string;
-  name: string;
-  role?: 'owner' | 'admin' | 'member';
-  createdAt: number;
-};
+export type { Workspace } from '../types/workspace';
 
 export type ProjectStatus = 'draft' | 'published';
 

--- a/src/types/workspace.ts
+++ b/src/types/workspace.ts
@@ -1,0 +1,6 @@
+export interface Workspace {
+  id: string;
+  name: string;
+  role?: 'owner' | 'admin' | 'member';
+  createdAt: number;
+}


### PR DESCRIPTION
## Summary
- introduce reusable `Workspace` interface
- type AppShell workspace state and handler
- ensure store functions use and return `Workspace`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 48 errors, 16 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68add4469f5c8323b02806dde913fc21